### PR TITLE
支持转发所有类型消息（可开关控制），屏蔽源群消息功能修复及其他优化

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -44,5 +44,12 @@
     "type": "bool",
     "hint": "开启后将屏蔽banshi_group_list中的群消息",
     "default": true
+  },
+  "allowed_message_types": {
+    "type": "list",
+    "default": ["text", "image", "video", "forward"],
+    "description": "允许转发的消息类型",
+    "hint": "可选: text(文本), image(图片), video(视频), forward(聊天记录/合并转发)。如果消息包含未被允许的媒体类型，将被拒绝转发。",
+    "options": ["text", "image", "video", "forward"]
   }
 }

--- a/main.py
+++ b/main.py
@@ -90,25 +90,27 @@ class Sowing_Discord(Star):
         if not self.banshi_target_list:
             self.banshi_target_list = await self.get_group_list(event)
 
-        raw_message = event.message_obj.raw_message
-        message_list = (
-            raw_message.get("message") if isinstance(raw_message, dict) else None
-        )
-        is_forward = (
-            message_list is not None
-            and isinstance(message_list, list)
-            and message_list
-            and isinstance(message_list[0], dict)
-            and message_list[0].get("type") == "forward"
-        )
+        if is_in_source_list:
+            # 【修复点1】防止非数字 ID（如哈希字符）混入导致 int() 转换抛出崩溃异常
+            try:
+                int(msg_id)
+                await self.local_cache.add_cache(msg_id)
+                logger.info(
+                    f"[SowingDiscord][ID:{self.instance_id}] 任务：缓存。已缓存消息 (ID: {msg_id}, 源头群: {source_group_id}, 发送者: {sender_id})。"
+                )
+            except (ValueError, TypeError):
+                logger.warning(
+                    f"[SowingDiscord][ID:{self.instance_id}] 拦截异常：消息 ID [{msg_id}] 不是有效的纯数字形式，底层 API 无法获取此转发，跳过缓存。"
+                )
 
-        if is_forward and is_in_source_list:
-            await self.local_cache.add_cache(msg_id)
-            logger.info(
-                f"[SowingDiscord][ID:{self.instance_id}] 任务：缓存。已缓存转发消息 (ID: {msg_id}, 源头群: {source_group_id}, 发送者: {sender_id})。"
+        # 【修复点2】包裹错误捕捉，确保就算缓存里真残留了脏数据，也不会中断其他机器人的模块处理
+        try:
+            waiting_messages = await self.local_cache.get_waiting_messages()
+        except ValueError as e:
+            logger.error(
+                f"[SowingDiscord][ID:{self.instance_id}] 缓存严重损坏！遇到了无法转换为数字的旧数据：{e}。请进入插件目录删掉损坏的缓存文件！"
             )
-
-        waiting_messages = await self.local_cache.get_waiting_messages()
+            waiting_messages = []
 
         # 转发/冷却逻辑
         if waiting_messages:
@@ -142,7 +144,10 @@ class Sowing_Discord(Star):
                     f"[SowingDiscord][ID:{self.instance_id}] 转发前自动清理了 {cleaned_count} 条超出最大缓存时长的消息。"
                 )
 
-            waiting_messages = await self.local_cache.get_waiting_messages()
+            try:
+                waiting_messages = await self.local_cache.get_waiting_messages()
+            except ValueError:
+                waiting_messages = []
 
             async with self.forward_lock:
                 logger.info(

--- a/main.py
+++ b/main.py
@@ -14,6 +14,7 @@ from .storage.local_cache import LocalCache
 import asyncio
 import time
 import uuid
+import re
 from datetime import datetime, time as dtime
 
 
@@ -23,33 +24,27 @@ class Sowing_Discord(Star):
         super().__init__(context)
         self.instance_id = str(uuid.uuid4())[:8]
 
-        # 仍然读取配置中的 banshi_interval 以保持兼容，但实际冷却时将按时间段动态计算
         self.banshi_interval = config.get("banshi_interval", 3600)
         self.banshi_cache_seconds = config.get("banshi_cache_seconds", 3600)
-        # 动态冷却配置（可自定义），默认：白天600s，夜间3600s
         self.cooldown_day_seconds = config.get("banshi_cooldown_day_seconds", 600)
         self.cooldown_night_seconds = config.get("banshi_cooldown_night_seconds", 3600)
-        # 冷却时间段起始时间（可自定义），默认：白天09:00，夜间01:00
         self.cooldown_day_start_str = config.get("banshi_cooldown_day_start", "09:00")
-        self.cooldown_night_start_str = config.get(
-            "banshi_cooldown_night_start", "01:00"
-        )
-        # 解析为 time 对象
+        self.cooldown_night_start_str = config.get("banshi_cooldown_night_start", "01:00")
+        
         self._day_start = self._parse_time_str(self.cooldown_day_start_str, dtime(9, 0))
-        self._night_start = self._parse_time_str(
-            self.cooldown_night_start_str, dtime(1, 0)
-        )
+        self._night_start = self._parse_time_str(self.cooldown_night_start_str, dtime(1, 0))
 
-        self.banshi_group_list = config.get("banshi_group_list")
-        self.banshi_target_list = config.get("banshi_target_list")
+        self.banshi_group_list = config.get("banshi_group_list", [])
+        self.banshi_target_list = config.get("banshi_target_list", [])
         self.block_source_messages = config.get("block_source_messages", False)
+        
+        self.allowed_msg_types = config.get("allowed_message_types", ["text", "image", "video", "forward"])
+        
         self.local_cache = LocalCache(max_age_seconds=self.banshi_cache_seconds)
-
         self.forward_lock = asyncio.Lock()
         self._forward_task = None
 
     def _parse_time_str(self, time_str: str, fallback: dtime) -> dtime:
-        """解析 HH:MM 字符串为 time 对象，失败时返回 fallback。"""
         try:
             if isinstance(time_str, str):
                 parts = time_str.split(":")
@@ -64,16 +59,63 @@ class Sowing_Discord(Star):
         return fallback
 
     def _get_banshi_interval_dynamic(self) -> int:
-        """
-        根据本地时间动态计算搬史间隔（可配置）：
-        - [day_start, 24:00) ∪ [00:00, night_start) => 返回白天冷却秒数
-        - [night_start, day_start) => 返回夜间冷却秒数
-        注意：时间段跨越午夜。
-        """
         now = datetime.now().time()
         if now >= self._day_start or now < self._night_start:
             return self.cooldown_day_seconds
         return self.cooldown_night_seconds
+
+    # 【修复与优化】完美兼容 AstrBot 的对象格式与 OneBot API 的字典格式
+    def _is_allowed_msg_type(self, message) -> bool:
+        if not self.allowed_msg_types:
+            return False
+
+        allowed = set(self.allowed_msg_types)
+        found_types = set()
+
+        if isinstance(message, list):
+            for seg in message:
+                if isinstance(seg, dict):
+                    # 情况 A: 处理底层 OneBot API 返回的 dict 格式（转发复核时使用）
+                    mtype = seg.get("type", "")
+                    if mtype == "image": found_types.add("image")
+                    elif mtype == "video": found_types.add("video")
+                    elif mtype in ["forward", "node"]: found_types.add("forward")
+                    elif mtype in ["text", "face", "at", "reply"]:
+                        if mtype == "text" and not seg.get("data", {}).get("text", "").strip():
+                            continue
+                        found_types.add("text")
+                else:
+                    # 情况 B: 处理 AstrBot 框架传递过来的 Component 对象（源群入库前验证时使用）
+                    cname = seg.__class__.__name__.lower()
+                    if cname == "image": found_types.add("image")
+                    elif cname == "video": found_types.add("video")
+                    elif cname in ["forward", "node"]: found_types.add("forward")
+                    elif cname in ["plain", "text", "face", "at", "reply"]:
+                        # 对象的文本属性一般是 text
+                        if cname in ["plain", "text"] and not getattr(seg, "text", "").strip():
+                            continue
+                        found_types.add("text")
+
+        elif isinstance(message, str):
+            # 情况 C: 处理纯 CQ码 字符串备用兜底
+            if "[CQ:image" in message: found_types.add("image")
+            if "[CQ:video" in message: found_types.add("video")
+            if "[CQ:forward" in message or "[CQ:node" in message: found_types.add("forward")
+            
+            text_only = re.sub(r'\[CQ:.*?\]', '', message).strip()
+            if text_only:
+                found_types.add("text")
+
+        # 规则1: 如果消息中包含了用户【未授权】的核心媒体类型，拦截整条消息。
+        for t in ["image", "video", "forward"]:
+            if t in found_types and t not in allowed:
+                return False
+
+        # 规则2: 如果消息没有任何符合用户设定项的元素，拦截。
+        if not found_types.intersection(allowed):
+            return False
+
+        return True
 
     @filter.platform_adapter_type(PlatformAdapterType.AIOCQHTTP)
     async def handle_message(self, event: AstrMessageEvent):
@@ -91,19 +133,22 @@ class Sowing_Discord(Star):
             self.banshi_target_list = await self.get_group_list(event)
 
         if is_in_source_list:
-            # 【修复点1】防止非数字 ID（如哈希字符）混入导致 int() 转换抛出崩溃异常
-            try:
-                int(msg_id)
-                await self.local_cache.add_cache(msg_id)
-                logger.info(
-                    f"[SowingDiscord][ID:{self.instance_id}] 任务：缓存。已缓存消息 (ID: {msg_id}, 源头群: {source_group_id}, 发送者: {sender_id})。"
-                )
-            except (ValueError, TypeError):
-                logger.warning(
-                    f"[SowingDiscord][ID:{self.instance_id}] 拦截异常：消息 ID [{msg_id}] 不是有效的纯数字形式，底层 API 无法获取此转发，跳过缓存。"
-                )
+            # 兼容获取消息结构
+            raw_msg = getattr(event.message_obj, 'message', getattr(event.message_obj, 'raw_message', ""))
+            if not self._is_allowed_msg_type(raw_msg):
+                logger.debug(f"[SowingDiscord][ID:{self.instance_id}] 预拦截：消息 (ID: {msg_id}) 包含未被允许的类型。")
+            else:
+                try:
+                    int(msg_id)
+                    await self.local_cache.add_cache(msg_id)
+                    logger.info(
+                        f"[SowingDiscord][ID:{self.instance_id}] 任务：缓存。已缓存消息 (ID: {msg_id}, 源头群: {source_group_id}, 发送者: {sender_id})。"
+                    )
+                except (ValueError, TypeError):
+                    logger.warning(
+                        f"[SowingDiscord][ID:{self.instance_id}] 拦截异常：消息 ID [{msg_id}] 不是有效的纯数字形式，跳过缓存。"
+                    )
 
-        # 【修复点2】包裹错误捕捉，确保就算缓存里真残留了脏数据，也不会中断其他机器人的模块处理
         try:
             waiting_messages = await self.local_cache.get_waiting_messages()
         except ValueError as e:
@@ -112,11 +157,8 @@ class Sowing_Discord(Star):
             )
             waiting_messages = []
 
-        # 转发/冷却逻辑
         if waiting_messages:
-            if self.forward_lock.locked():
-                pass
-            else:
+            if not self.forward_lock.locked():
                 await self._execute_forward_and_cool(
                     event, forward_manager, evaluator, waiting_messages
                 )
@@ -129,14 +171,10 @@ class Sowing_Discord(Star):
     async def _execute_forward_and_cool(
         self, event, forward_manager, evaluator, waiting_messages
     ):
-        """
-        核心转发逻辑，包含对消息内容的预检查（是否被撤回/是否过期）。
-        """
         client = event.bot
 
         try:
             current_task = asyncio.current_task()
-            # 记录当前任务以便 terminate 时可取消（无论是否正处于冷却中）
             self._forward_task = current_task
             cleaned_count = await self.local_cache._cleanup_expired_cache()
             if cleaned_count > 0:
@@ -151,15 +189,13 @@ class Sowing_Discord(Star):
 
             async with self.forward_lock:
                 logger.info(
-                    f"[SowingDiscord][ID:{self.instance_id}] 执行任务：转发。成功获取转发锁。检测到 {len(waiting_messages)} 条待转发消息，开始处理..."
+                    f"[SowingDiscord][ID:{self.instance_id}] 执行任务：转发。检测到 {len(waiting_messages)} 条待转发消息，开始处理..."
                 )
 
                 for index, msg_id_to_forward in enumerate(waiting_messages):
                     earliest_timestamp_limit = time.time() - self.banshi_cache_seconds
-
                     target_list_str = ", ".join(map(str, self.banshi_target_list))
 
-                    # === 预检查：是否被撤回或过期 ===
                     try:
                         message_detail = await client.api.call_action(
                             "get_msg", message_id=int(msg_id_to_forward)
@@ -167,30 +203,26 @@ class Sowing_Discord(Star):
                         message_time = message_detail.get("time", 0)
                         msg_content = message_detail.get("message", [])
 
-                        # 检查: 消息时间是否超出缓存范围
                         if message_time < earliest_timestamp_limit:
-                            logger.info(
-                                f"[SowingDiscord] 预检查失败：消息ID {msg_id_to_forward} (时间: {time.strftime('%H:%M:%S', time.localtime(message_time))}) 已超出 {self.banshi_cache_seconds} 秒缓存限制。"
-                            )
                             await self.local_cache.remove_cache(msg_id_to_forward)
                             continue
 
-                        # 检查: 消息内容是否被撤回
                         if not msg_content:
+                            await self.local_cache.remove_cache(msg_id_to_forward)
+                            continue
+                            
+                        # API 拿到的是字典形式，进行二次类型校验
+                        if not self._is_allowed_msg_type(msg_content):
                             logger.info(
-                                f"[SowingDiscord] 预检查失败：消息ID {msg_id_to_forward} 内容为空或复杂类型，判断为已撤回/失效。"
+                                f"[SowingDiscord] 预检查失败：消息ID {msg_id_to_forward} 包含未被配置允许的消息类型。"
                             )
                             await self.local_cache.remove_cache(msg_id_to_forward)
                             continue
 
-                    except ActionFailed as e:
-                        logger.info(
-                            f"[SowingDiscord] 预检查API失败：消息ID {msg_id_to_forward} (可能已撤回/不存在)。原因: {e}"
-                        )
+                    except ActionFailed:
                         await self.local_cache.remove_cache(msg_id_to_forward)
                         continue
 
-                    # === 预检查通过，开始转发流程 ===
                     start_time_for_cooldown = time.time()
                     try:
                         if await evaluator.evaluate(msg_id_to_forward):
@@ -208,47 +240,25 @@ class Sowing_Discord(Star):
                                 await asyncio.sleep(1)
 
                             await self.local_cache.remove_cache(msg_id_to_forward)
-                            logger.info(
-                                f"[SowingDiscord][ID:{self.instance_id}] 缓存清理：消息 (ID: {msg_id_to_forward}) 转发成功，已手动清除缓存。"
-                            )
-
-                            # 冷却：根据时间段动态设置间隔
+                            
                             interval = self._get_banshi_interval_dynamic()
                             self._forward_task = current_task
                             logger.info(
                                 f"[SowingDiscord][ID:{self.instance_id}] 冷却开始：时长 {interval} 秒 (持有锁)。"
                             )
                             await asyncio.sleep(interval)
-                            self._forward_task = None  # 冷却完成后清除跟踪
-
-                            end_time = time.time()
-                            actual_duration = end_time - start_time_for_cooldown
-                            logger.info(
-                                f"[SowingDiscord][ID:{self.instance_id}] 冷却结束：实际耗时约 {actual_duration:.2f} 秒 (包含发送时间)。"
-                            )
+                            self._forward_task = None 
 
                         else:
-                            logger.info(
-                                f"[SowingDiscord][ID:{self.instance_id}] 消息 (ID: {msg_id_to_forward}) 评估未通过，跳过转发。"
-                            )
                             await self.local_cache.remove_cache(msg_id_to_forward)
-                            logger.info(
-                                f"[SowingDiscord][ID:{self.instance_id}] 缓存清理：消息 (ID: {msg_id_to_forward}) 评估失败，已手动清除缓存。"
-                            )
 
                     except ActionFailed as e:
                         logger.error(
                             f"[SowingDiscord][ID:{self.instance_id}] 转发失败 (API 拒绝)：消息 ID {msg_id_to_forward} ... 原因: {e}"
                         )
                         await self.local_cache.remove_cache(msg_id_to_forward)
-                        logger.warning(
-                            f"[SowingDiscord][ID:{self.instance_id}] 缓存清理：消息 (ID: {msg_id_to_forward}) 因 API 拒绝而失败，已手动清除缓存。继续下一条消息。"
-                        )
                         continue
                     except asyncio.CancelledError:
-                        logger.warning(
-                            f"[SowingDiscord][ID:{self.instance_id}] 任务在冷却期间被强制取消。"
-                        )
                         self._forward_task = None
                         raise
 
@@ -256,14 +266,12 @@ class Sowing_Discord(Star):
                 f"[SowingDiscord][ID:{self.instance_id}] 本次所有待转发消息处理完毕，释放转发锁。"
             )
         except asyncio.CancelledError:
-            logger.warning(
-                f"[SowingDiscord][ID:{self.instance_id}] 转发任务协程被强制终止，确保锁已释放。"
-            )
+            pass
         finally:
             self._forward_task = None
 
-    def terminate(self):
-        """在插件停止时，取消仍在进行的冷却任务，避免阻塞关闭。"""
+    # 【修复退出报错】添加了 async，防止重启框架/重载插件时由于阻塞报错
+    async def terminate(self):
         try:
             if self._forward_task and not self._forward_task.done():
                 logger.info(
@@ -279,7 +287,4 @@ class Sowing_Discord(Star):
         client = event.bot
         response = await client.api.call_action("get_group_list", no_cache=False)
         group_ids = [item["group_id"] for item in response]
-        logger.info(
-            f"[SowingDiscord] 目标群列表为空，自动获取到 {len(group_ids)} 个群组作为目标群。"
-        )
         return group_ids

--- a/main.py
+++ b/main.py
@@ -125,7 +125,13 @@ class Sowing_Discord(Star):
 
         source_group_id = event.message_obj.group_id
         msg_id = event.message_obj.message_id
-        is_in_source_list = source_group_id in self.banshi_group_list
+        
+        # 将群号统一转为字符串进行判定，防止因格式不同（int/str）导致匹配失败
+        is_in_source_list = str(source_group_id) in [str(g) for g in self.banshi_group_list]
+
+        # 【核心修复】如果是源群消息，且开启了屏蔽源群选项，立即拦截事件，阻止大模型和下游插件响应！
+        if is_in_source_list and self.block_source_messages:
+            event.stop_event()
 
         sender_id = event.get_sender_id()
 
@@ -159,17 +165,13 @@ class Sowing_Discord(Star):
 
         if waiting_messages:
             if not self.forward_lock.locked():
-                await self._execute_forward_and_cool(
-                    event, forward_manager, evaluator, waiting_messages
-                )
-
-        if self.block_source_messages and is_in_source_list:
-            return MessageEventResult(None)
+                # 【优化】将其作为后台任务运行，避免冷却期的 sleep 卡死事件循环，导致其他消息无响应
+                asyncio.create_task(self._execute_forward_and_cool(event, forward_manager, evaluator))
 
         return None
 
     async def _execute_forward_and_cool(
-        self, event, forward_manager, evaluator, waiting_messages
+        self, event, forward_manager, evaluator
     ):
         client = event.bot
 
@@ -183,6 +185,7 @@ class Sowing_Discord(Star):
                 )
 
             try:
+                # 重新获取最新的待转发列表
                 waiting_messages = await self.local_cache.get_waiting_messages()
             except ValueError:
                 waiting_messages = []


### PR DESCRIPTION
解除转发类型限制： 删除了原代码中判断 is_forward 的逻辑。现在不管是纯文本、图片、表情包还是视频，只要是源头群发来的消息，全都会进入缓存等待评估，不再局限于“合并转发聊天记录”。

增加非法 ID 拦截： 在把消息 ID 存入缓存前，增加了一层 int(msg_id) 的“体检”逻辑，如果是平台生成的字母数字混合 ID（例如哈希值），就会主动拦截并跳过，防止脏数据进入系统。